### PR TITLE
fix(react): Fix channelId reference

### DIFF
--- a/server.js
+++ b/server.js
@@ -359,7 +359,7 @@ client.on('messageCreate', message => {
   }
 
   //check for politics in main
-  if (message.channel_id == vapeNayshChannelId) {
+  if (message.channelId == vapeNayshChannelId) {
     let formattedMessage = message.content.toLowerCase();
     const bannedPhrases = Object.keys(vapeNayshBans);
     bannedPhrases.forEach(bannedPhrase => {


### PR DESCRIPTION
Use the correct reference for `channelId` associated with a message to filter which channels are filtered